### PR TITLE
Added a post-collision weight window check for multigroup mode.

### DIFF
--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -19,6 +19,7 @@
 #include "openmc/settings.h"
 #include "openmc/simulation.h"
 #include "openmc/tallies/tally.h"
+#include "openmc/weight_windows.h"
 
 namespace openmc {
 
@@ -29,6 +30,9 @@ void collision_mg(Particle& p)
 
   // Sample the reaction type
   sample_reaction(p);
+  if (settings::weight_windows_on) {
+    apply_weight_windows(p);
+  }
 
   // Display information about collision
   if ((settings::verbosity >= 10) || p.trace()) {


### PR DESCRIPTION
I've added a weight-window check for multigroup mode using the same structure already in place for continuous-energy mode.

